### PR TITLE
fix end_col for selections

### DIFF
--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -176,7 +176,6 @@ local function parse_prompt(prompt)
 		)
 		text = text:gsub("$sel", table.concat(sel_text, "\n"))
 	end
-  print(text)
 
 	return text
 end

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -171,11 +171,12 @@ local function parse_prompt(prompt)
 			sel_start[2] - 1,
 			sel_start[3] - 1,
 			sel_end[2] - 1,
-			sel_end[3] - 1,
+			sel_end[3],  -- end_col is exclusive
 			{}
 		)
 		text = text:gsub("$sel", table.concat(sel_text, "\n"))
 	end
+  print(text)
 
 	return text
 end


### PR DESCRIPTION
This fixes the `end_col` index for the selection - it is exclusive so no need to subtract `-1`.