### PR TITLE
implemented display_prompt action

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ the prompt string with context in the following ways:
   - Uses the `extract` pattern to extract the response.
 - `display_insert`: Stream and display the response in a floating window, then insert the response at the current cursor line.
   - Uses the `extract` pattern to extract the response.
+- `display_prompt`: Append the parsed prompt and stream and display the response in a floating window.
 
 Sometimes, you may need functionality that is not provided by
 the built-in actions. In this case, you can write your own Custom Actions with the following interface:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ return {
       desc = "ollama prompt",
       mode = { "n", "v" },
     },
-    
+
     -- Sample keybind for direct prompting. Note that the <c-u> is important for selections to work properly.
     {
       "<leader>oG",
@@ -169,7 +169,7 @@ the prompt string with context in the following ways:
   - Uses the `extract` pattern to extract the response.
 - `display_insert`: Stream and display the response in a floating window, then insert the response at the current cursor line.
   - Uses the `extract` pattern to extract the response.
-- `display_prompt`: Append the parsed prompt and stream and display the response in a floating window.
+- `display_prompt`: Display the parsed prompt and stream and display the response below in a floating window.
 
 Sometimes, you may need functionality that is not provided by
 the built-in actions. In this case, you can write your own Custom Actions with the following interface:

--- a/lua/ollama/actions.lua
+++ b/lua/ollama/actions.lua
@@ -249,7 +249,7 @@ actions.display_prompt = {
 	fn = function(prompt)
 		local input_label = prompt.input_label or "> "
 		local display_prompt = input_label .. " " .. prompt.parsed_prompt .. "\n\n"
-		local tokens = { display_prompt .. "\n\n" }
+		local tokens = { display_prompt .. "\n" }
 		local out_buf = vim.api.nvim_create_buf(false, true)
 		require("ollama.util").open_floating_win(out_buf, { title = prompt.model })
 		-- show a rotating spinner while waiting for the response

--- a/lua/ollama/actions.lua
+++ b/lua/ollama/actions.lua
@@ -287,13 +287,9 @@ actions.display_prompt = {
 			if body.done then
 				timer:stop()
 				timer:stop()
-				vim.api.nvim_buf_set_lines(
-					out_buf,
-					#pre_lines,
-					#pre_lines + 1,
-					false,
-					{ ("> Done: %ss."):format(require("ollama.util").nano_to_seconds(body.total_duration)) }
-				)
+				vim.api.nvim_buf_set_lines(out_buf, #pre_lines, #pre_lines + 1, false, {
+					("> %s in %ss."):format(prompt.model, require("ollama.util").nano_to_seconds(body.total_duration)),
+				})
 				vim.api.nvim_set_option_value("modifiable", false, { buf = out_buf })
 			end
 		end

--- a/lua/ollama/actions.lua
+++ b/lua/ollama/actions.lua
@@ -247,7 +247,8 @@ actions.display_insert = {
 
 actions.display_prompt = {
 	fn = function(prompt)
-		local display_prompt = prompt.input_label .. " " .. prompt.parsed_prompt
+		local input_label = prompt.input_label or "> "
+		local display_prompt = input_label .. " " .. prompt.parsed_prompt .. "\n\n"
 		local tokens = { display_prompt .. "\n\n" }
 		local out_buf = vim.api.nvim_create_buf(false, true)
 		require("ollama.util").open_floating_win(out_buf, { title = prompt.model })

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -41,7 +41,7 @@ local M = {}
 ---@field top_p float? Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)
 
 ---Built-in actions
----@alias Ollama.PromptActionBuiltinEnum "display" | "replace" | "insert" | "display_replace" | "display_insert"
+---@alias Ollama.PromptActionBuiltinEnum "display" | "replace" | "insert" | "display_replace" | "display_insert" | "display_prompt"
 
 -- Handles the output of a prompt. Custom Actions can be defined in lieu of a builtin.
 ---@alias Ollama.PromptAction table | Ollama.PromptActionFields

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -264,6 +264,7 @@ function M.prompt(name)
 		input_label = prompt.input_label,
 		extract = parsed_extract,
 		action = action,
+		parsed_prompt = parsed_prompt,
 	})
 
 	if not cb then

--- a/lua/ollama/prompts.lua
+++ b/lua/ollama/prompts.lua
@@ -14,6 +14,7 @@ local prompts = {
 	Raw = {
 		prompt = "$input",
 		input_label = ">",
+		action = "display_prompt",
 	},
 
 	Simplify_Code = {

--- a/lua/ollama/util.lua
+++ b/lua/ollama/util.lua
@@ -24,20 +24,22 @@ end
 ---@param display_prompt string The prompt to display before the spinner (optional)
 ---@return uv_timer_t timer The timer object for rotating the spinner
 function util.show_spinner(bufnr, display_prompt)
+	local display_prompt_table = {}
+	if display_prompt ~= nil then
+		display_prompt_table = vim.split(display_prompt, "\n")
+	end
 	local spinner_chars = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
 	local curr_char = 1
+	local prompt_spinner_table = {}
 	local timer = vim.loop.new_timer()
 	timer:start(
 		100,
 		100,
 		vim.schedule_wrap(function()
-			local replacement_string = {}
-			if display_prompt == nil then
-				replacement_string = { "Generating... " .. spinner_chars[curr_char], "" }
-			else
-				replacement_string = { display_prompt , "", "", "Generating... " .. spinner_chars[curr_char], "" }
-			end
-			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, replacement_string)
+			prompt_spinner_table = { table.unpack(display_prompt_table) }
+			table.insert(prompt_spinner_table, "> Generating... " .. spinner_chars[curr_char])
+			table.insert(prompt_spinner_table, "" )
+			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, prompt_spinner_table)
 			curr_char = curr_char % #spinner_chars + 1
 		end)
 	)

--- a/lua/ollama/util.lua
+++ b/lua/ollama/util.lua
@@ -21,8 +21,9 @@ end
 
 -- Show a spinner in the given buffer (overwrites existing lines)
 ---@param bufnr number The buffer to show the spinner in
+---@param display_prompt string The prompt to display before the spinner (optional)
 ---@return uv_timer_t timer The timer object for rotating the spinner
-function util.show_spinner(bufnr)
+function util.show_spinner(bufnr, display_prompt)
 	local spinner_chars = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
 	local curr_char = 1
 	local timer = vim.loop.new_timer()
@@ -30,7 +31,13 @@ function util.show_spinner(bufnr)
 		100,
 		100,
 		vim.schedule_wrap(function()
-			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "Generating... " .. spinner_chars[curr_char], "" })
+			local replacement_string = {}
+			if display_prompt == nil then
+				replacement_string = { "Generating... " .. spinner_chars[curr_char], "" }
+			else
+				replacement_string = { display_prompt , "", "", "Generating... " .. spinner_chars[curr_char], "" }
+			end
+			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, replacement_string)
 			curr_char = curr_char % #spinner_chars + 1
 		end)
 	)

--- a/lua/ollama/util.lua
+++ b/lua/ollama/util.lua
@@ -20,9 +20,9 @@ function util.handle_stream(cb)
 end
 
 ---@class Ollama.Util.ShowSpinnerOptions
----@field start_ln number The line to start the spinner at
----@field end_ln number The line to end the spinner at
----@field format string The format string to use for the spinner line
+---@field start_ln number? The line to start the spinner at
+---@field end_ln number? The line to end the spinner at
+---@field format string? The format string to use for the spinner line
 
 -- Show a spinner in the given buffer (overwrites existing lines)
 ---@param bufnr number The buffer to show the spinner in


### PR DESCRIPTION
It can be useful to have the prompt displayed in the floating window as well, e.g. for the Raw input, but also can give a sense of the exact prompt that is used to query the LLM. To this end I'v added a `display_prompt` action that is a bit more involved than making a custom action - it needs the `parsed_prompt` as input, and the `show_spinner` needs to be modified as well.

Here it is in action:

![ollama display prompt](https://github.com/nomnivore/ollama.nvim/assets/15214418/40eae8b8-a416-4471-9cf8-566242ab3d22)
