### PR TITLE
Chat is working, some printout issues

### DIFF
--- a/lua/ollama/actions.lua
+++ b/lua/ollama/actions.lua
@@ -301,4 +301,65 @@ actions.display_prompt = {
 	},
 }
 
+
+actions.chat = {
+	fn = function()
+    local out_buf = vim.api.nvim_get_current_buf()
+		local pre_lines = vim.api.nvim_buf_get_lines(out_buf, 0, -1, false)
+    local tokens = {}
+		-- show a rotating spinner while waiting for the response
+		local timer = require("ollama.util").show_spinner(
+		  out_buf,
+		  { start_ln = #pre_lines, end_ln = #pre_lines + 1 }
+		) -- the +1 makes sure the old spinner is replaced
+		-- empty line so that the response lands in the right place
+		vim.api.nvim_buf_set_lines(out_buf, -1, -1, false, { "" })
+
+		---@type Job?
+		local job
+		local is_cancelled = false
+		vim.api.nvim_buf_attach(out_buf, false, {
+			on_detach = function()
+				if job ~= nil then
+					is_cancelled = true
+					job:shutdown()
+				end
+			end,
+		})
+
+		---@type Ollama.PromptActionResponseCallback
+		return function(body, _job)
+			if job == nil and _job ~= nil then
+				job = _job
+				if is_cancelled then
+					timer:stop()
+					job:shutdown()
+				end
+			end
+			table.insert(tokens, body.response)
+			vim.api.nvim_buf_set_lines(
+			  out_buf, #pre_lines + 1, -1, false, vim.split(table.concat(tokens), "\n")
+			)
+
+			if body.done then
+				timer:stop()
+				vim.api.nvim_buf_set_lines(out_buf, #pre_lines, #pre_lines + 1, false, {
+					("> Ollama in %ss."):format(
+            require("ollama.util").nano_to_seconds(body.total_duration)
+          )
+        })
+			vim.api.nvim_buf_set_lines(
+			  out_buf, -1, -1, false, vim.split("\n\n> User\n", "\n")
+			)
+      -- vim.api.nvim_win_set_cursor(0, { -1, 0 }) -- simpler to use norm
+      vim.cmd [[ norm G ]]
+      vim.cmd [[ w ]]
+			end
+		end
+	end,
+
+	opts = {
+		stream = true,
+	},
+}
 return actions

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -317,6 +317,31 @@ function M.prompt(name)
 	add_job(job)
 end
 
+--- create new chat buffer and window
+function M.create_chat()
+  local out_buf = vim.api.nvim_create_buf(true, false)  -- create a normal buffer
+  local out_win = vim.api.nvim_get_current_win()
+  vim.api.nvim_set_current_buf(out_buf)
+  vim.api.nvim_buf_set_name(out_buf, "/tmp/ollama-chat.md")
+  vim.api.nvim_set_option_value("filetype", "markdown", { buf = out_buf })
+  -- vim.api.nvim_set_option_value("buftype", "nofile", { buf = out_buf })
+  vim.api.nvim_set_option_value("wrap", true, { win = out_win })
+  vim.api.nvim_set_option_value("linebreak", true, { win = out_win })
+  local pre_text = [[
+You are an AI agent called Ollama that is helping the User with his queries.
+The User enters their prompts after lines beginning with '> User'.
+Your answers start at lines beginning with '> Ollama'.
+You should output only responses and not the special sequences '> User' and '> Ollama'.
+
+> User
+]]
+  local pre_lines = vim.split(pre_text, "\n")
+  vim.api.nvim_buf_set_lines(out_buf, 0, -1, false, pre_lines)
+  vim.api.nvim_win_set_cursor(0, { #pre_lines, 0 })
+  vim.cmd [[w!]]  --overwrite file if exists TODO manage chats in an ollama folder
+  vim.api.nvim_buf_set_keymap(out_buf, "n", "q", "<cmd>bd!<cr>", { noremap = true })
+end
+
 ---@class Ollama.ModelsApiResponseModel
 ---@field name string
 ---@field modified_at string

--- a/lua/ollama/prompts.lua
+++ b/lua/ollama/prompts.lua
@@ -35,6 +35,13 @@ local prompts = {
 		prompt = "Generate $ftype code that does the following: $input\n\n" .. response_format,
 		action = "insert",
 	},
+  Chat = {
+    prompt = "$buf\n",
+    -- input_label = ">",
+    action = "chat",
+    extract = false,
+    -- model = model_lang,
+  },
 }
 
 return prompts


### PR DESCRIPTION
I've implemented some basic chat here (#7 ):

![ollama chat](https://github.com/nomnivore/ollama.nvim/assets/15214418/8070342e-74d2-4086-afed-6835d954aeb2)

The whole chat gets passed each time to Ollama, so the buffer can be modified as freely. Sometimes Ollama does start  talking to itself :thinking: I've tried to prevent this with the initial setup. It also has some issues with new lines but all in all it works ok :sweat_smile: 

The user can start a Chat session and chat using the `create_chat()` and `chat()` functions. I've mapped them like so:
```lua
  keys = {
    {
      "<leader>oc",
      ":<c-u>lua require('ollama').create_chat()<cr>",
      -- ":<c-u>Ollama<cr>",
      desc = "Create Ollama Chat",
      mode = { "n" },
      silent = true,
    },
    {
      "<leader>opc",
      ":<c-u>lua require('ollama').prompt('Chat')<cr>",
      -- ":<c-u>Ollama<cr>",
      desc = "Ollama Chat",
      mode = { "n" },
      silent = true,
    },
},
```