### PR TITLE
Added dedicated code model

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To get a fuzzy-finding Telescope prompt selector you can optionally install [`st
 ```lua
 opts = {
   model = "mistral",
+  model_code = "codellama",
   url = "http://127.0.0.1:11434",
   serve = {
     on_start = false,
@@ -98,6 +99,7 @@ opts = {
   }
 }
 ```
+The model `model_code` will be used with the built-in prompts concerning code, e.g. `Explain Code`. To use the default `model` for the code prompts as well, set this to an empty string, i.e. `model_code = ""`.
 
 ### Docker
 

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -74,8 +74,8 @@ local M = {}
 
 function M.default_config()
 	return {
-    model = "mistral",
-    model_code = "codellama",
+		model = "mistral",
+		model_code = "codellama",
 		url = "http://127.0.0.1:11434",
 		prompts = {},  -- generated in setup
 		serve = {
@@ -449,9 +449,9 @@ end
 function M.setup(opts)
 	---@diagnostic disable-next-line: assign-type-mismatch
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
-  M.config.prompts = require("ollama.prompts").generate_prompts(
-    M.config.model, M.config.model_code
-  )
+	M.config.prompts = require("ollama.prompts").generate_prompts(
+		M.config.model, M.config.model_code
+	)
 
 	-- add command
 	vim.api.nvim_create_user_command("Ollama", function(arg)

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -74,9 +74,10 @@ local M = {}
 
 function M.default_config()
 	return {
-		model = "mistral",
+    model = "mistral",
+    model_code = "codellama",
 		url = "http://127.0.0.1:11434",
-		prompts = require("ollama.prompts"),
+		prompts = {},  -- generated in setup
 		serve = {
 			on_start = false,
 			command = "ollama",
@@ -448,6 +449,9 @@ end
 function M.setup(opts)
 	---@diagnostic disable-next-line: assign-type-mismatch
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+  M.config.prompts = require("ollama.prompts").generate_prompts(
+    M.config.model, M.config.model_code
+  )
 
 	-- add command
 	vim.api.nvim_create_user_command("Ollama", function(arg)

--- a/lua/ollama/prompts.lua
+++ b/lua/ollama/prompts.lua
@@ -2,91 +2,91 @@ local prompts = {}
 local response_format = "Respond EXACTLY in this format:\n```$ftype\n<your code>\n```"
 
 function prompts.generate_prompts(model, model_code)
-  if model_code == nil then
-    model_code = model
-  end
-  local prompts_table = {
-    -- code based prompts
-    Raw_Code = {
-      prompt = "$input",
-      input_label = ">",
-      action = "display",
-      model = model_code,
-    },
+	if model_code == nil then
+		model_code = model
+	end
+	local prompts_table = {
+		-- code based prompts
+		Raw_Code = {
+			prompt = "$input",
+			input_label = ">",
+			action = "display",
+			model = model_code,
+		},
 
-    Ask_About_Code = {
-      prompt = "I have a question about this: $input\n\n Here is the code:\n```$ftype\n$sel```",
-      input_label = "Q",
-      model = model_code,
-    },
+		Ask_About_Code = {
+			prompt = "I have a question about this: $input\n\n Here is the code:\n```$ftype\n$sel```",
+			input_label = "Q",
+			model = model_code,
+		},
 
-    Explain_Code = {
-      prompt = "Explain this code:\n```$ftype\n$sel\n```",
-      model = model_code,
-    },
+		Explain_Code = {
+			prompt = "Explain this code:\n```$ftype\n$sel\n```",
+			model = model_code,
+		},
 
-    Simplify_Code = {
-      prompt = "Simplify the following $ftype code so that it is both easier to read and understand. "
-        .. response_format
-        .. "\n\n```$ftype\n$sel```",
-      action = "replace",
-      model = model_code,
-    },
+		Simplify_Code = {
+			prompt = "Simplify the following $ftype code so that it is both easier to read and understand. "
+				.. response_format
+				.. "\n\n```$ftype\n$sel```",
+			action = "replace",
+			model = model_code,
+		},
 
-    Modify_Code = {
-      prompt = "Modify this $ftype code in the following way: $input\n\n"
-        .. response_format
-        .. "\n\n```$ftype\n$sel```",
-      action = "replace",
-      model = model_code,
-    },
+		Modify_Code = {
+			prompt = "Modify this $ftype code in the following way: $input\n\n"
+				.. response_format
+				.. "\n\n```$ftype\n$sel```",
+			action = "replace",
+			model = model_code,
+		},
 
-    Generate_Code = {
-      prompt = "Generate $ftype code that does the following: $input\n\n" .. response_format,
-      action = "insert",
-      model = model_code,
-    },
+		Generate_Code = {
+			prompt = "Generate $ftype code that does the following: $input\n\n" .. response_format,
+			action = "insert",
+			model = model_code,
+		},
 
-    -- text based prompts
-    Raw = {
-      prompt = "$input",
-      input_label = ">",
-      action = "display",
-      model = model,
-    },
+		-- text based prompts
+		Raw = {
+			prompt = "$input",
+			input_label = ">",
+			action = "display",
+			model = model,
+		},
 
-    Ask_About_Text = {
-      prompt = "I have a question about this: $input\n\n Here is the text:\n\n$sel",
-      input_label = "Q",
-      model = model,
-    },
+		Ask_About_Text = {
+			prompt = "I have a question about this: $input\n\n Here is the text:\n\n$sel",
+			input_label = "Q",
+			model = model,
+		},
 
-    Explain_Text = {
-      prompt = "Explain this text:\n\n$sel",
-      model = model,
-    },
+		Explain_Text = {
+			prompt = "Explain this text:\n\n$sel",
+			model = model,
+		},
 
-    Simplify_Text = {
-      prompt = "Simplify the following text so that it is both easier to read and understand. "
-        .. "\n\n$sel",
-      action = "replace",
-      model = model,
-    },
+		Simplify_Text = {
+			prompt = "Simplify the following text so that it is both easier to read and understand. "
+				.. "\n\n$sel",
+			action = "replace",
+			model = model,
+		},
 
-    Modify_Text = {
-      prompt = "Modify this text in the following way: $input\n\n$sel",
-      action = "replace",
-      model = model,
-    },
+		Modify_Text = {
+			prompt = "Modify this text in the following way: $input\n\n$sel",
+			action = "replace",
+			model = model,
+		},
 
-    Generate_Text = {
-      prompt = "Generate text that does the following: $input\n\n",
-      action = "insert",
-      model = model,
-    },
-  }
+		Generate_Text = {
+			prompt = "Generate text that does the following: $input\n\n",
+			action = "insert",
+			model = model,
+		},
+	}
 
-  return prompts_table
+	return prompts_table
 end
 
 return prompts

--- a/lua/ollama/prompts.lua
+++ b/lua/ollama/prompts.lua
@@ -1,40 +1,92 @@
+local prompts = {}
 local response_format = "Respond EXACTLY in this format:\n```$ftype\n<your code>\n```"
 
-local prompts = {
-	Ask_About_Code = {
-		prompt = "I have a question about this: $input\n\n Here is the code:\n```$ftype\n$sel```",
-		input_label = "Q",
-	},
+function prompts.generate_prompts(model, model_code)
+  if model_code == nil then
+    model_code = model
+  end
+  local prompts_table = {
+    -- code based prompts
+    Raw_Code = {
+      prompt = "$input",
+      input_label = ">",
+      action = "display",
+      model = model_code,
+    },
 
-	Explain_Code = {
-		prompt = "Explain this code:\n```$ftype\n$sel\n```",
-	},
+    Ask_About_Code = {
+      prompt = "I have a question about this: $input\n\n Here is the code:\n```$ftype\n$sel```",
+      input_label = "Q",
+      model = model_code,
+    },
 
-	-- basically "no prompt"
-	Raw = {
-		prompt = "$input",
-		input_label = ">",
-		action = "display",
-	},
+    Explain_Code = {
+      prompt = "Explain this code:\n```$ftype\n$sel\n```",
+      model = model_code,
+    },
 
-	Simplify_Code = {
-		prompt = "Simplify the following $ftype code so that it is both easier to read and understand. "
-			.. response_format
-			.. "\n\n```$ftype\n$sel```",
-		action = "replace",
-	},
+    Simplify_Code = {
+      prompt = "Simplify the following $ftype code so that it is both easier to read and understand. "
+        .. response_format
+        .. "\n\n```$ftype\n$sel```",
+      action = "replace",
+      model = model_code,
+    },
 
-	Modify_Code = {
-		prompt = "Modify this $ftype code in the following way: $input\n\n"
-			.. response_format
-			.. "\n\n```$ftype\n$sel```",
-		action = "replace",
-	},
+    Modify_Code = {
+      prompt = "Modify this $ftype code in the following way: $input\n\n"
+        .. response_format
+        .. "\n\n```$ftype\n$sel```",
+      action = "replace",
+      model = model_code,
+    },
 
-	Generate_Code = {
-		prompt = "Generate $ftype code that does the following: $input\n\n" .. response_format,
-		action = "insert",
-	},
-}
+    Generate_Code = {
+      prompt = "Generate $ftype code that does the following: $input\n\n" .. response_format,
+      action = "insert",
+      model = model_code,
+    },
+
+    -- text based prompts
+    Raw = {
+      prompt = "$input",
+      input_label = ">",
+      action = "display",
+      model = model,
+    },
+
+    Ask_About_Text = {
+      prompt = "I have a question about this: $input\n\n Here is the text:\n\n$sel",
+      input_label = "Q",
+      model = model,
+    },
+
+    Explain_Text = {
+      prompt = "Explain this text:\n\n$sel",
+      model = model,
+    },
+
+    Simplify_Text = {
+      prompt = "Simplify the following text so that it is both easier to read and understand. "
+        .. "\n\n$sel",
+      action = "replace",
+      model = model,
+    },
+
+    Modify_Text = {
+      prompt = "Modify this text in the following way: $input\n\n$sel",
+      action = "replace",
+      model = model,
+    },
+
+    Generate_Text = {
+      prompt = "Generate text that does the following: $input\n\n",
+      action = "insert",
+      model = model,
+    },
+  }
+
+  return prompts_table
+end
 
 return prompts


### PR DESCRIPTION
`codellama` performs better than other models when asking about code. This PR enables users to optionally have a separate `code_model` from the default `model` used for general prompts. 

It also adds symmetrical text based prompts to the original code based prompts. Maybe they could be trimmed :thinking: 