### PR TITLE
Adds $to_cursor token

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,15 +181,16 @@ will then be sent to the action associated with the prompt.
 Before sending the prompt, `ollama.nvim` will replace certain special tokens in
 the prompt string with context in the following ways:
 
-| Token  | Description                              |
-| ------ | ---------------------------------------- |
-| $input | Prompt the user for input.               |
-| $sel   | The current or previous selection.       |
-| $ftype | The filetype of the current buffer.      |
-| $fname | The filename of the current buffer.      |
-| $buf   | The full contents of the current buffer. |
-| $line  | The current line in the buffer.          |
-| $lnum  | The current line number in the buffer.   |
+| Token      | Description                              |
+| ---------- | ---------------------------------------- |
+| $input     | Prompt the user for input.               |
+| $sel       | The current or previous selection.       |
+| $ftype     | The filetype of the current buffer.      |
+| $fname     | The filename of the current buffer.      |
+| $buf       | The full contents of the current buffer. |
+| $line      | The current line in the buffer.          |
+| $lnum      | The current line number in the buffer.   |
+| $to_cursor | The text up to the cursor                |
 
 ### Actions
 

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -183,6 +183,17 @@ local function parse_prompt(prompt)
 		text = text:gsub("$sel", table.concat(sel_text, "\n"))
 	end
 
+	if text:find("$to_cursor") then
+		local cursor_loc = vim.api.nvim_win_get_cursor(0)
+		-- get the lines for the current buffer, up to the cursor
+		lines = vim.api.nvim_buf_get_lines(0, 0, cursor_loc[1], false)
+		lines[#lines] = string.sub(lines[#lines], 0, cursor_loc[2]+1)
+		
+		complete = table.concat(lines, "\n")
+		-- remove last \n char
+		return string.sub(complete, 0, -1)
+	end
+
 	return text
 end
 


### PR DESCRIPTION
This adds a token that will take all of the current buffer up to the cursor. This can be very useful for code completion tasks. In the screenshot the cursor was placed on the "l" of "assetsFile".

<img width="1326" alt="Screenshot 2024-03-15 at 12 46 37 PM" src="https://github.com/nomnivore/ollama.nvim/assets/11822845/ccfc932a-f508-4fdd-8b14-d697cf9168f5">
