### PR TITLE
Replace `nvim_buf_set_text`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
 return {
-  "yamsergey/ollama.nvim",
+  "nomnivore/ollama.nvim",
   dependencies = {
     "nvim-lua/plenary.nvim",
   },

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
 return {
-  "nomnivore/ollama.nvim",
+  "yamsergey/ollama.nvim",
   dependencies = {
     "nvim-lua/plenary.nvim",
   },

--- a/lua/ollama/actions/factory.lua
+++ b/lua/ollama/actions/factory.lua
@@ -142,7 +142,8 @@ function factory.create_action(opts)
 
 						if opts.replace then
 							local start_line, start_col, end_line, end_col = unpack(sel_pos)
-							vim.api.nvim_buf_set_text(bufnr, start_line, start_col, end_line, end_col, lines)
+							vim.api.nvim_buf_set_lines(bufnr, start_line, end_line, false, {})
+							vim.api.nvim_buf_set_lines(bufnr, start_line, start_line, false, lines)							
 						elseif opts.insert then
 							vim.api.nvim_buf_set_lines(bufnr, cursorLine, cursorLine, false, lines)
 						end


### PR DESCRIPTION
As described in this comment https://github.com/nomnivore/ollama.nvim/issues/29#issuecomment-2072461964, I've changed behavior of `replace` function by using `nvim_buf_set_lines` instead of `nvim_buf_set_text`.  

As the first step I delete all selected lines:

```lua
vim.api.nvim_buf_set_lines(bufnr, start_line, end_line, false, {})
```

And then insert all lines into the document starting from the first selected line:

```lua
vim.api.nvim_buf_set_lines(bufnr, start_line, start_line, false, lines)
```

P.S.
It also gives an opportunity for enhancement, after deletion we can insert the lines whenever user cursor is. But I will involve some calculations if the cursor below the deleted lines, not hard though.

P.S. P.S.

README changes related to `LazyVim` configuration example, I changed the GitHub path, because I'm lazy.