### PR TITLE
Add support for $before and $after

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,15 +181,17 @@ will then be sent to the action associated with the prompt.
 Before sending the prompt, `ollama.nvim` will replace certain special tokens in
 the prompt string with context in the following ways:
 
-| Token  | Description                              |
-| ------ | ---------------------------------------- |
-| $input | Prompt the user for input.               |
-| $sel   | The current or previous selection.       |
-| $ftype | The filetype of the current buffer.      |
-| $fname | The filename of the current buffer.      |
-| $buf   | The full contents of the current buffer. |
-| $line  | The current line in the buffer.          |
-| $lnum  | The current line number in the buffer.   |
+| Token   | Description                                            |
+| ------- | ------------------------------------------------------ |
+| $input  | Prompt the user for input.                             |
+| $sel    | The current or previous selection.                     |
+| $ftype  | The filetype of the current buffer.                    |
+| $fname  | The filename of the current buffer.                    |
+| $buf    | The full contents of the current buffer.               |
+| $before | The contents of the current buffer, before the pointer |
+| $after  | The contents of the current buffer, after the pointer  |
+| $line   | The current line in the buffer.                        |
+| $lnum   | The current line number in the buffer.                 |
 
 ### Actions
 

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -172,17 +172,20 @@ local function parse_prompt(prompt)
 			sel_end[3] = sel_end[3] - 1
 		end
 
-		local sel_text = vim.api.nvim_buf_get_text(
-			-- TODO: check if buf exists
-			---@diagnostic disable-next-line: param-type-mismatch
-			vim.fn.bufnr("%"),
-			sel_start[2] - 1,
-			sel_start[3] - 1,
-			sel_end[2] - 1,
-			sel_end[3], -- end_col is exclusive
-			{}
-		)
-		text = text:gsub("$sel", table.concat(sel_text, "\n"))
+		local buf_nr = vim.fn.bufnr("%")
+
+		if buf_nr ~= -1 then
+			local sel_text = vim.api.nvim_buf_get_text(
+				---@diagnostic disable-next-line: param-type-mismatch
+				buf_nr,
+				sel_start[2] - 1,
+				sel_start[3] - 1,
+				sel_end[2] - 1,
+				sel_end[3], -- end_col is exclusive
+				{}
+			)
+			text = text:gsub("$sel", table.concat(sel_text, "\n"))
+		end
 	end
 
 	return text

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -140,7 +140,9 @@ end
 ---@param prompt Ollama.Prompt
 local function parse_prompt(prompt)
 	local text = prompt.prompt
-	if text:find("$input") then
+	local original_text = text
+
+	if original_text:find("$input") then
 		local input_prompt = prompt.input_label or "> "
 		-- add space to end if not there
 		if input_prompt:sub(-1) ~= " " then
@@ -155,12 +157,12 @@ local function parse_prompt(prompt)
 	text = text:gsub("$line", vim.fn.getline("."))
 	text = text:gsub("$lnum", tostring(vim.fn.line(".")))
 
-	if text:find("$buf") then
+	if original_text:find("$buf") then
 		local buf_text = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 		text = text:gsub("$buf", table.concat(buf_text, "\n"))
 	end
 
-	if text:find("$sel") then
+	if original_text:find("$sel") then
 		local sel_start = vim.fn.getpos("'<") or { 0, 0, 0, 0 }
 		local sel_end = vim.fn.getpos("'>") or { 0, 0, 0, 0 }
 


### PR DESCRIPTION
Some models support FIM, for which it is extremely useful, to have access to the text, before, and after the cursor, in the current buffer.

Example Model: https://ollama.com/library/codegemma *it is written at the bottom of the README*