### PR TITLE
feat: Add `insert_after_selection` and `display_insert_after_selection` actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,13 @@ the prompt string with context in the following ways:
   - Uses the `extract` pattern to extract the response.
 - `insert`: Insert the response at the current cursor line
   - Uses the `extract` pattern to extract the response.
+- `insert_after_selection`: Insert the response after the previous selection.
+  - Uses the `extract` pattern to extract the response.
 - `display_replace`: Stream and display the response in a floating window, then replace the current selection with the response.
   - Uses the `extract` pattern to extract the response.
 - `display_insert`: Stream and display the response in a floating window, then insert the response at the current cursor line.
+  - Uses the `extract` pattern to extract the response.
+- `display_insert_after_selection`: Stream and display the response in a floating window, then insert the response after the previous selection.
   - Uses the `extract` pattern to extract the response.
 
 Sometimes, you may need functionality that is not provided by

--- a/lua/ollama/actions/init.lua
+++ b/lua/ollama/actions/init.lua
@@ -7,6 +7,8 @@ actions.display = factory.create_action({ display = true, show_prompt = true })
 
 actions.insert = factory.create_action({ display = false, insert = true })
 
+actions.insert_after_selection = factory.create_action({ display = false, insert_after_selection = true })
+
 actions.replace = factory.create_action({ display = false, replace = true })
 
 -- basically a merge of display -> replace actions
@@ -17,6 +19,8 @@ actions.display_replace = factory.create_action({
 })
 
 actions.display_insert = factory.create_action({ insert = true, show_prompt = true })
+
+actions.display_insert_after_selection = factory.create_action({ insert_after_selection = true, show_prompt = true })
 
 -- TODO: remove this as its not used anymore
 -- if you use this in your config, please switch to "display" instead

--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -41,7 +41,7 @@ local M = {}
 ---@field top_p float? Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)
 
 ---Built-in actions
----@alias Ollama.PromptActionBuiltinEnum "display" | "replace" | "insert" | "display_replace" | "display_insert" | "display_prompt"
+---@alias Ollama.PromptActionBuiltinEnum "display" | "replace" | "insert" | "insert_after_selection" | "display_replace" | "display_insert" | "display_insert_after_selection" | "display_prompt"
 
 -- Handles the output of a prompt. Custom Actions can be defined in lieu of a builtin.
 ---@alias Ollama.PromptAction table | Ollama.PromptActionFields

--- a/lua/ollama/prompts.lua
+++ b/lua/ollama/prompts.lua
@@ -31,6 +31,13 @@ local prompts = {
 		action = "replace",
 	},
 
+	Comment_Code = {
+		prompt = "Rewrite the following $ftype code."
+			.. response_format
+			.. "\n\n```$ftype\n$sel```",
+		action = "insert_after_selection",
+	},
+
 	Generate_Code = {
 		prompt = "Generate $ftype code that does the following: $input\n\n" .. response_format,
 		action = "insert",


### PR DESCRIPTION
Currently, executing a prompt with the `insert` action with multiple lines, the generated content will be inserted after the first selected line.
This change allows ollama answers to be inserted after the previously made selection.
This is helpful for e.g. rewriting text and still being able to check the differences.