### PR TITLE
feat: Add server_status() function

### DIFF
--- a/lua/ollama/init.lua
+++ b/lua/ollama/init.lua
@@ -91,6 +91,8 @@ M.config = M.default_config()
 
 ---@alias Ollama.StatusEnum "WORKING" | "IDLE"
 
+---@alias Ollama.ServerStatusEnum "UP" | "DOWN"
+
 local jobs = {}
 local jobs_length = 0
 
@@ -453,6 +455,22 @@ function M.run_serve(opts)
 	})
 	serve_job:start()
 	-- TODO: can we check if the server started successfully from this job?
+end
+
+-- Query the status of the Ollama server
+--- @type fun(): Ollama.ServerStatusEnum
+function M.server_status()
+    local status = "DOWN"
+    local query_job = require("plenary.job"):new({
+        command = "ollama",
+        args =  { "list" },
+        on_exit = function(_, code)
+            if code == 0 then
+                status = "UP"
+            end
+        end
+    }):sync()
+    return status
 end
 
 -- Stop the ollama server


### PR DESCRIPTION
Currently, the only way to check if the Ollama server is running is to invoke some sort of command that uses the server and see if the command fails. It would be nice if there was a way to query the status of the server in a simpler way. For example, I use this function in my lualine configuration so I don't have to rerun `:OllamaServe` every time I forget if the server is running or not.

I've tried to implement this similarly to other functions in the plugin but I'm not super familiar with neovim plugin code conventions so it's possible there is a better way to write this.